### PR TITLE
Add a binder badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # berpublicsearch-defaults
 A collection of notebooks to quantify the extent of default values in the BER Public search database
+
+To try it out for yourself click on the Binder Badge below
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/codema-dev/berpublicsearch-defaults/HEAD?filepath=notebooks%2Fcount_berpublicsearch_uvaluewall_defaults.ipynb)


### PR DESCRIPTION
Enables anyone with a link to this Github to run the notebooks themselves in-browser